### PR TITLE
Add --from-entry-point option to globalScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-cli-commons": "~0.2.0",
+    "@akashic/akashic-cli-commons": "~0.2.1",
     "aac-duration": "0.0.1",
     "commander": "2.8.1",
     "fs-readdir-recursive": "1.0.0",

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -208,6 +208,15 @@ export class Configuration extends cmn.Configuration {
 			});
 	}
 
+	scanGlobalScriptsFromEntryPoint(): Promise<void> {
+		var entryPointPath = this._content.main || ("./" + path.join(this._basepath, this._content.assets["mainScene"].path));
+		return Promise.resolve()
+			.then(() => cmn.NodeModules.listModuleFiles(this._basepath, entryPointPath))
+			.then((filePaths: string[]) => {
+				this._content.globalScripts = filePaths;
+			});
+	}
+
 	vacuumXXX(
 		dir: string,
 		type: string,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,10 +38,11 @@ commander
 	.command("globalScripts")
 	.description("Update 'globalScripts' property of game.json")
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
+	.option("-e, --from-entry-point", "Scan from the entrypoint instead of `npm ls`")
 	.option("-q, --quiet", "Suppress output")
 	.action((opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
-		promiseScanNodeModules({ cwd: opts.cwd, logger: logger })
+		promiseScanNodeModules({ cwd: opts.cwd, logger: logger, fromEntryPoint: opts.fromEntryPoint })
 			.catch((err: any) => {
 				logger.error(err);
 				process.exit(1);

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -84,6 +84,13 @@ export interface ScanNodeModulesParameterObject {
 	logger?: cmn.Logger;
 
 	/**
+	 * エントリポイントスクリプトの内容からスキャンするようにするか否か。
+	 * 省略された場合、偽。
+	 * 偽である場合、 `npm ls` して得られたモジュール名一覧からスキャンする。
+	 */
+	fromEntryPoint?: boolean;
+
+	/**
 	 * デバッグ用のNPMを受け取る。
 	 * 省略された場合、NPMを引き渡さない。
 	 */
@@ -93,6 +100,7 @@ export interface ScanNodeModulesParameterObject {
 export function _completeScanNodeModulesParameterObject(param: ScanNodeModulesParameterObject): void {
 	param.cwd = param.cwd || process.cwd();
 	param.logger = param.logger || new cmn.ConsoleLogger();
+	param.fromEntryPoint = param.fromEntryPoint || false;
 }
 
 export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): Promise<void> {
@@ -108,7 +116,7 @@ export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): P
 				debugNpm: param.debugNpm
 			});
 			return Promise.resolve()
-				.then(() => conf.scanGlobalScripts())
+				.then(() => (param.fromEntryPoint ? conf.scanGlobalScriptsFromEntryPoint() : conf.scanGlobalScripts()))
 				.then(() => cmn.ConfigurationFile.write(conf.getContent(), "./game.json", param.logger))
 				.then(() => param.logger.info("Done!"));
 		})


### PR DESCRIPTION
## このpull requestが解決する内容

現状の `akashic scan globalScirpts` は、 babel-runtime のような「モジュール全体を require() できないモジュール」に対応していません。 (babel-runtime は常に `require("babel-runtime/foo/bar")` のような形で利用されていて、 index.js などがないため `require("babel-runtime")` とは書けません)　これは `scan globalScripts` が、 `npm ls` で列挙されたモジュール名から依存ファイルを探索するためです。

このようなケースを救うため、 `npm ls` の結果ではなく game.json の main (スクリプトアセットのエントリポイント) から探索するオプション `--from-entry-point` を追加します。このオプションはもしかすると既存実装をまるごと代替できるかもしれませんが、ひとまず様子見したいのでデフォルト挙動にはしません。(エントリポイントから browserify に辿れる形で参照されているものしか列挙できないので、既存実装とはまた別の制限があります)

https://github.com/akashic-games/akashic-cli-commons/pull/4 に依存しています。動作確認には当該 PR を link する必要があります。

## 破壊的な変更を含んでいるか?

なし