### PR TITLE
drop aac warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-scan",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Command line tool for updating assets and globalScripts.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/getAudioDuration.ts
+++ b/src/getAudioDuration.ts
@@ -9,9 +9,6 @@ export function getAudioDuration(filepath: string, logger?: cmn.Logger): Promise
 	var ext = path.extname(filepath);
 	switch (ext) {
 	case ".aac":
-		if (logger) {
-			logger.warn("[deprecated] " + path.basename(filepath) + " uses deprecated format. Use MP4(AAC) instead of AAC.");
-		}
 		var d: number;
 		try {
 			d = aacDuration(filepath);
@@ -30,6 +27,9 @@ export function getAudioDuration(filepath: string, logger?: cmn.Logger): Promise
 			});
 		});
 	case ".mp4":
+		if (logger) {
+			logger.warn("[deprecated] " + path.basename(filepath) + " uses deprecated format. Use AAC instead of MP4(AAC).");
+		}
 		var n: number;
 		try {
 			var data = fs.readFileSync(filepath);


### PR DESCRIPTION
## このpull requestが解決する内容

オーディオ形式の変更（MP4→AAC）に伴い、AAC利用時に出力されていた警告メッセージを削除します。

## 破壊的な変更を含んでいるか?
なし