### PR TITLE
Update package.json and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ language: node_js
 node_js:
 - 6.10
 - 8.11
-- 10.6
+- 10.4
+# mock-fsが node v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "@types/node": "6.0.46",
+    "@types/node": "~10.12.0",
     "@types/jasmine": "~2.8.2",
     "@types/mock-fs": "~3.6.30",
     "@types/image-size": "0.0.29",


### PR DESCRIPTION
## このpull requestが解決する内容

TravisCIのnode v10でエラーとなる問題の修正
 - 必要なpackageを最新に修正
 - .travis.yml のnodeのv10系の指定を10.4へ修正
     - mock-fsにてnode v10.5以上の場合、fs.Promiseのcallbackが動作しない問題があるため